### PR TITLE
Arbitrary query variables

### DIFF
--- a/src/wired/component.tsx
+++ b/src/wired/component.tsx
@@ -170,7 +170,8 @@ function getClientInitialProps<ServerSideProps>(
   }
 
   const env = opts.createClientEnvironment();
-  const variables = ctx.query;
+  const queryVariables = opts.queryVariables ? opts.queryVariables(ctx) : {};
+  const variables = { ...ctx.query, ...queryVariables };
   const preloadedQuery = loadQuery(env, query, variables, {
     fetchPolicy: 'store-and-network',
   });

--- a/src/wired/component.tsx
+++ b/src/wired/component.tsx
@@ -33,6 +33,9 @@ export interface WiredOptions<ServerSideProps = {}> {
   serverSideProps?: (
     ctx: NextPageContext
   ) => Promise<ServerSideProps | { redirect: Redirect }>;
+
+  //TODO: Incomplete, can we infer query variables type here?
+  queryVariables: (ctx: NextPageContext) => { [key: string]: any };
 }
 
 export type WiredProps<
@@ -110,8 +113,11 @@ async function getServerInitialProps<ServerSideProps>(
   }
 
   const env = await opts.createServerEnvironment(ctx, serverSideProps);
-  const variables = ctx.query;
-  const preloadedQuery = loadQuery(env, query, variables);
+  const variables = opts.queryVariables(ctx);
+  const preloadedQuery = loadQuery(env, query, {
+    ...ctx.query,
+    ...variables,
+  });
 
   try {
     await ensureQueryFlushed(preloadedQuery);

--- a/src/wired/component.tsx
+++ b/src/wired/component.tsx
@@ -35,7 +35,7 @@ export interface WiredOptions<ServerSideProps = {}> {
   ) => Promise<ServerSideProps | { redirect: Redirect }>;
 
   //TODO: Incomplete, can we infer query variables type here?
-  queryVariables: (ctx: NextPageContext) => { [key: string]: any };
+  queryVariables?: (ctx: NextPageContext) => { [key: string]: any };
 }
 
 export type WiredProps<
@@ -113,7 +113,7 @@ async function getServerInitialProps<ServerSideProps>(
   }
 
   const env = await opts.createServerEnvironment(ctx, serverSideProps);
-  const variables = opts.queryVariables(ctx);
+  const variables = opts.queryVariables ? opts.queryVariables(ctx) : {};
   const preloadedQuery = loadQuery(env, query, {
     ...ctx.query,
     ...variables,

--- a/website/docs/page-api.md
+++ b/website/docs/page-api.md
@@ -14,8 +14,8 @@ import { graphql, usePreloadedQuery } from 'react-relay/hooks';
 
 // The $uuid variable is injected automatically from the route.
 const ProfileQuery = graphql`
-  query profile_ProfileQuery($uuid: ID!) {
-    user(id: $uuid) {
+  query profile_ProfileQuery($uuid: ID!, $active: Boolean) {
+    user(id: $uuid, active: $active) {
       id
       firstName
       lastName
@@ -67,6 +67,9 @@ const options: RelayOptions<{ token: string }> = {
     const { createServerEnvironment } = await import('lib/server_environment');
     return createServerEnvironment(token);
   },
+  queryVariables: (ctx) => ({
+    active: true,
+  }),
 };
 ```
 
@@ -81,6 +84,8 @@ const options: RelayOptions<{ token: string }> = {
   you should import server-only deps with `await import('...')`.
 - `createServerEnvironment`: A function that returns a `RelayEnvironment`. First argument
   is `NextPageContext` and the second is the object returned by `serverSideProps`.
+- `queryVariables`: Pass any variables into the query. Variables defined here will have precedence
+  over variables injected from the route
 
 ## `getRelaySerializedState`
 

--- a/website/docs/page-api.md
+++ b/website/docs/page-api.md
@@ -84,8 +84,10 @@ const options: RelayOptions<{ token: string }> = {
   you should import server-only deps with `await import('...')`.
 - `createServerEnvironment`: A function that returns a `RelayEnvironment`. First argument
   is `NextPageContext` and the second is the object returned by `serverSideProps`.
-- `queryVariables`: Pass any variables into the query. Variables defined here will have precedence
-  over variables injected from the route
+- `clientSideQueryVariables`: Pass any variables into the query. Variables defined here will have precedence
+  over variables injected from the route.
+- `serverSideQueryVariables`: Same as above but this function will run on the server.
+  Both functions should return same result.
 
 ## `getRelaySerializedState`
 


### PR DESCRIPTION
Hi, current version of library only passes variables from the route. This pull request is for changes that allow passing arbitrary variables to the query.  Haven't defined proper variable types, maybe someone with deeper typescript skills can have a crack at it, other than that should be pretty straight forward change