### PR TITLE
Allow user to use custom error boundry component

### DIFF
--- a/src/wired/component.tsx
+++ b/src/wired/component.tsx
@@ -44,6 +44,7 @@ export interface WiredOptions<Props extends WiredProps, ServerSideProps = {}> {
   serverSideProps?: (
     ctx: NextPageContext
   ) => Promise<ServerSideProps | { redirect: Redirect }>;
+  ErrorComponent?: React.ComponentType<any>;
 }
 
 function defaultVariablesFromContext(
@@ -72,7 +73,7 @@ export function Wire<Props extends WiredProps, ServerSideProps>(
 
     if (props.CSN) {
       return (
-        <WiredErrorBoundry>
+        <WiredErrorBoundry ErrorComponent={opts.ErrorComponent}>
           <Suspense fallback={opts.fallback ?? 'Loading...'}>
             <Component {...props} preloadedQuery={queryReference} />
           </Suspense>

--- a/src/wired/error_boundry.tsx
+++ b/src/wired/error_boundry.tsx
@@ -1,7 +1,9 @@
 import Error from 'next/error';
 import React, { Component, PropsWithChildren } from 'react';
 
-type WiredErrorBoundryProps = PropsWithChildren<unknown>;
+type WiredErrorBoundryProps = PropsWithChildren<{
+  ErrorComponent?: React.ComponentType<any>;
+}>;
 
 interface WiredErrorBoundryState {
   hasError: boolean;
@@ -18,8 +20,14 @@ export class WiredErrorBoundry extends Component<
   state = { hasError: false };
 
   render() {
+    const ErrorComponent = this.props.ErrorComponent;
+
     if (this.state.hasError) {
-      return <Error statusCode={500} />;
+      return ErrorComponent ? (
+        <ErrorComponent statusCode={500} />
+      ) : (
+        <Error statusCode={500} />
+      );
     } else {
       return this.props.children;
     }


### PR DESCRIPTION
I was wondering why our custom error page is not working for Relay related errors.

Our solution is to allow maintainers to add a new `ErrorComponent`  option to `withRelay` but still defaults to the plain Error page when the option is not provided.