### PR TITLE
Add prop types to script element

### DIFF
--- a/src/wired/document.tsx
+++ b/src/wired/document.tsx
@@ -14,7 +14,7 @@ type AppEnhancer = NonNullable<RenderPageOptions['enhanceApp']>;
 
 export interface WiredDocument {
   enhance: AppEnhancer;
-  Script: ComponentType;
+  Script: ComponentType<React.ScriptHTMLAttributes<HTMLScriptElement>>;
 }
 
 export function createWiredDocument(): WiredDocument {


### PR DESCRIPTION
Props were already being passed to the script element, the interface just lacked the prop typings.

Fixes #38