### PR TITLE
Make fetch policy configurable

### DIFF
--- a/src/wired/component.tsx
+++ b/src/wired/component.tsx
@@ -8,7 +8,12 @@ import React, {
   useMemo,
   useState,
 } from 'react';
-import { loadQuery, PreloadedQuery, useQueryLoader } from 'react-relay/hooks';
+import {
+  loadQuery,
+  PreloadedQuery,
+  PreloadFetchPolicy,
+  useQueryLoader,
+} from 'react-relay/hooks';
 import {
   Environment,
   GraphQLTaggedNode,
@@ -56,6 +61,7 @@ export interface WiredOptions<Props extends WiredProps, ServerSideProps = {}> {
     ctx: NextPageContext
   ) => Promise<OrRedirect<ServerSideProps>>;
   ErrorComponent?: WiredErrorBoundaryProps['ErrorComponent'];
+  fetchPolicy?: PreloadFetchPolicy;
 }
 
 function defaultVariablesFromContext(
@@ -206,7 +212,7 @@ function getClientInitialProps<Props extends WiredProps, ClientSideProps>(
   const env = opts.createClientEnvironment();
   const variables = variablesFromContext(ctx);
   const preloadedQuery = loadQuery(env, query, variables, {
-    fetchPolicy: 'store-and-network',
+    fetchPolicy: opts.fetchPolicy || 'store-and-network',
   });
 
   const context = createWiredClientContext({

--- a/website/docs/page-api.md
+++ b/website/docs/page-api.md
@@ -51,6 +51,7 @@ Interface for configuring `withRelay`. Example usage:
 ```tsx
 const options: RelayOptions<{ token: string }> = {
   fallback: <Loading />,
+  fetchPolicy: 'store-and-network',
   createClientEnvironment: () => getClientEnvironment()!,
   serverSideProps: async (ctx) => {
     const { getTokenFromCtx } = await import('lib/server/auth');
@@ -74,6 +75,8 @@ const options: RelayOptions<{ token: string }> = {
 
 - `fallback?`: React component to use as a loading indicator. See
   [React Suspense docs](https://reactjs.org/docs/concurrent-mode-suspense.html).
+- `fetchPolicy?`: Relay fetch policy. Defaults to `store-and-network`. See
+  [Relay docs](https://relay.dev/docs/guided-tour/reusing-cached-data/fetch-policies/).
 - `clientSideProps?`: Provides props to the page on client-side navigations. Not
   required.
 - `createClientEnvironment`: A function that returns a `RelayEnvironment`.


### PR DESCRIPTION
Add (optional) `fetchPolicy` option to `RelayOptions`. Defaults to `store-and-network` so the change should be backwards compatible.

What I'd ideally want to do (not in this PR) is that we could use `store-and-network` on page change and `store-or-network` when only query params change. Do you think that would be doable? Just asking in case you already know, but I can also think about this later :)

From quick look I'm unsure how I would detect what the previous page was in the function where I need to decide fetch policy. or maybe it would be possible to move the decision to the actual react component. We'll see.