### PR TITLE
Pass error to ErrorComponent 

### DIFF
--- a/src/wired/error_boundry.tsx
+++ b/src/wired/error_boundry.tsx
@@ -9,8 +9,7 @@ export type WiredErrorBoundaryProps = PropsWithChildren<{
 }>;
 
 interface WiredErrorBoundaryState {
-  hasError: boolean;
-  error: NextPageContext['err'];
+  error?: NextPageContext['err'];
 }
 
 export class WiredErrorBoundary extends Component<
@@ -20,32 +19,17 @@ export class WiredErrorBoundary extends Component<
   static getDerivedStateFromError(
     error: NextPageContext['err']
   ): WiredErrorBoundaryState {
-    return { hasError: true, error };
+    return { error };
   }
-
-  state = {
-    hasError: false,
-    error: {
-      name: 'Error 500',
-      message: 'Unknown',
-      stack: 'Unknown',
-      statusCode: 500,
-    },
-  };
 
   render() {
     const ErrorComponent = this.props.ErrorComponent;
 
     // Something happened, let consumers decide what to do with this type of error
-    let error: NextPageContext['err'] = {
-      name: 'Error 500',
-      message: 'Unknown',
-      stack: 'Unknown',
-      statusCode: 500,
-    };
+    let error: NextPageContext['err'];
 
     // Because passing this.state.error won't work
-    if (this.state.hasError)
+    if (this.state.error)
       error = {
         name: 'Error 500',
         message: this.state.error ? this.state.error.toString() : 'Unknown',
@@ -55,7 +39,10 @@ export class WiredErrorBoundary extends Component<
         statusCode: 500,
       };
 
-    if (this.state.hasError) {
+    // eslint-disable-next-line no-console
+    console.log('error_boundary:error', error);
+
+    if (error) {
       return ErrorComponent ? (
         <ErrorComponent statusCode={500} error={error} />
       ) : (

--- a/src/wired/error_boundry.tsx
+++ b/src/wired/error_boundry.tsx
@@ -9,7 +9,7 @@ export type WiredErrorBoundaryProps = PropsWithChildren<{
 }>;
 
 interface WiredErrorBoundaryState {
-  error?: NextPageContext['err'];
+  error?: NextPageContext['err'] | false;
 }
 
 export class WiredErrorBoundary extends Component<
@@ -21,6 +21,8 @@ export class WiredErrorBoundary extends Component<
   ): WiredErrorBoundaryState {
     return { error };
   }
+
+  state: { error? : NextPageContext['err'] | false } = { error: false }
 
   render() {
     const ErrorComponent = this.props.ErrorComponent;

--- a/src/wired/error_boundry.tsx
+++ b/src/wired/error_boundry.tsx
@@ -27,25 +27,11 @@ export class WiredErrorBoundary extends Component<
   render() {
     const ErrorComponent = this.props.ErrorComponent;
 
-    // Something happened, let consumers decide what to do with this type of error
-    let error: NextPageContext['err'];
-
-    // Because passing this.state.error won't work
-    if (this.state.error)
-      error = {
-        name: 'Error 500',
-        message: this.state.error ? this.state.error.toString() : 'Unknown',
-        stack: this.state.error?.stack
-          ? this.state.error.stack.toString()
-          : 'Unknown',
-        statusCode: 500,
-      };
-
-    if (error) {
+    if (this.state.error) {
       return ErrorComponent ? (
-        <ErrorComponent statusCode={500} error={error} />
+        <ErrorComponent statusCode={500} error={this.state.error} />
       ) : (
-        <Error statusCode={500} error={error} />
+        <Error statusCode={500} error={this.state.error} />
       );
     } else {
       return this.props.children;

--- a/src/wired/error_boundry.tsx
+++ b/src/wired/error_boundry.tsx
@@ -39,9 +39,6 @@ export class WiredErrorBoundary extends Component<
         statusCode: 500,
       };
 
-    // eslint-disable-next-line no-console
-    console.log('error_boundary:error', error);
-
     if (error) {
       return ErrorComponent ? (
         <ErrorComponent statusCode={500} error={error} />

--- a/src/wired/error_boundry.tsx
+++ b/src/wired/error_boundry.tsx
@@ -1,32 +1,65 @@
 import Error, { ErrorProps } from 'next/error';
 import React, { Component, PropsWithChildren } from 'react';
+import { NextPageContext } from 'next';
 
 export type WiredErrorBoundaryProps = PropsWithChildren<{
-  ErrorComponent?: React.ComponentType<ErrorProps>;
+  ErrorComponent?: React.ComponentType<
+    ErrorProps & { error: NextPageContext['err'] }
+  >;
 }>;
 
 interface WiredErrorBoundaryState {
   hasError: boolean;
+  error: NextPageContext['err'];
 }
 
 export class WiredErrorBoundary extends Component<
   WiredErrorBoundaryProps,
   WiredErrorBoundaryState
 > {
-  static getDerivedStateFromError(): WiredErrorBoundaryState {
-    return { hasError: true };
+  static getDerivedStateFromError(
+    error: NextPageContext['err']
+  ): WiredErrorBoundaryState {
+    return { hasError: true, error };
   }
 
-  state = { hasError: false };
+  state = {
+    hasError: false,
+    error: {
+      name: 'Error 500',
+      message: 'Unknown',
+      stack: 'Unknown',
+      statusCode: 500,
+    },
+  };
 
   render() {
     const ErrorComponent = this.props.ErrorComponent;
 
+    // Something happened, let consumers decide what to do with this type of error
+    let error: NextPageContext['err'] = {
+      name: 'Error 500',
+      message: 'Unknown',
+      stack: 'Unknown',
+      statusCode: 500,
+    };
+
+    // Because passing this.state.error won't work
+    if (this.state.hasError)
+      error = {
+        name: 'Error 500',
+        message: this.state.error ? this.state.error.toString() : 'Unknown',
+        stack: this.state.error?.stack
+          ? this.state.error.stack.toString()
+          : 'Unknown',
+        statusCode: 500,
+      };
+
     if (this.state.hasError) {
       return ErrorComponent ? (
-        <ErrorComponent statusCode={500} />
+        <ErrorComponent statusCode={500} error={error} />
       ) : (
-        <Error statusCode={500} />
+        <Error statusCode={500} error={error} />
       );
     } else {
       return this.props.children;


### PR DESCRIPTION
Related to #48 

This will allow consumers to properly log errors in their ErrorComponent. IE: Sentry, BugSnag, etc. 