### PR TITLE
website: Fix "Edit this page" link

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -37,7 +37,7 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           editUrl:
-            'https://github.com/RevereCRE/relay-nextjs/edit/master/website/',
+            'https://github.com/RevereCRE/relay-nextjs/edit/main/website/',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
Current links lead to url like

https://github.com/RevereCRE/relay-nextjs/edit/master/website/docs/installation-and-setup.md

But should be

https://github.com/RevereCRE/relay-nextjs/edit/main/website/docs/installation-and-setup.md