### PR TITLE
docs: Update webpack.IgnorePlugin for web pack 5 (default in latest Next.js)

### DIFF
--- a/website/docs/installation-and-setup.md
+++ b/website/docs/installation-and-setup.md
@@ -98,11 +98,17 @@ pulling in server dependencies to the client bundle configure Webpack to ignore
 any files in `src/lib/server`. In `next.config.js`:
 
 ```js
+const webpack = require("webpack");
+
+//...
+
 module.exports = {
   webpack: (config, { isServer, webpack }) => {
     if (!isServer) {
       // Ensures no server modules are included on the client.
-      config.plugins.push(new webpack.IgnorePlugin(/lib\/server/));
+      config.plugins.push(
+        new webpack.IgnorePlugin({ resourceRegExp: /lib\/server/ })
+      );
     }
 
     return config;


### PR DESCRIPTION
Just got this

```
ValidationError: Invalid options object. Ignore Plugin has been initialized using an options object that does not match the API schema.
 - options should be one of these:
   object { resourceRegExp, contextRegExp? } | object { checkResource }
   Details:
    * options misses the property 'resourceRegExp'. Should be:
      RegExp
      -> A RegExp to test the request against.
    * options misses the property 'checkResource'. Should be:
      function
      -> A filter function for resource and context.
    at validate (~/node_modules/next/dist/compiled/schema-utils3/index.js:1:150822)
    at ~/node_modules/next/dist/compiled/webpack/bundle5.js:126431:17
    at new IgnorePlugin (~/node_modules/next/dist/compiled/webpack/bundle5.js:42929:3)
    at Object.webpack (~/next.config.js:46:27)
    at Object.webpack (~/node_modules/next-transpile-modules/src/next-transpile-modules.js:255:29)
    at Object.newWebpackFunction [as webpack] (~/node_modules/@sentry/nextjs/dist/config/webpack.js:40:40)
    at Object.getBaseWebpackConfig [as default] (~/node_modules/next/dist/build/webpack-config.js:1186:32)
    at async Promise.all (index 0)
    at async Span.traceAsyncFn (~/node_modules/next/dist/trace/trace.js:79:20)
    at async Span.traceAsyncFn (~/node_modules/next/dist/trace/trace.js:79:20) {
  errors: [
    {
      keyword: 'anyOf',
      dataPath: '',
      schemaPath: '#/anyOf',
      params: {},
      message: 'should match some schema in anyOf',
      schema: [Array],
      parentSchema: [Object],
      data: /lib\/server/,
      children: [Array]
    }
  ],
  schema: { title: 'IgnorePluginOptions', anyOf: [ [Object], [Object] ] },
  headerName: 'Ignore Plugin',
  baseDataPath: 'options',
  postFormatter: null
}
```

I checked official webpack docs: https://webpack.js.org/plugins/ignore-plugin/