### PR TITLE
Add serverSidePostQuery hook to access query data + NextContext during SSR

### DIFF
--- a/website/docs/page-api.md
+++ b/website/docs/page-api.md
@@ -90,6 +90,10 @@ const options: RelayOptions<{ token: string }> = {
 - `variablesFromContext?`: Function that extracts GraphQL query variables from
   `NextPageContext`. Run on both the client and server. If omitted query
   variables are set to `ctx.query`.
+- `serverSidePostQuery?`: Function that is called during server side rendering after
+  fetching the query is finished. First parameter gives you access to the data returned by your
+  query and the second parameter gives access to `NextPageContext`. This function can
+  be used for example to set your response status to 404 if your query didn't return data.
 
 ## `getRelaySerializedState`
 


### PR DESCRIPTION
Adds `serverSidePostQuery` function option to relay-nextjs which allows to access returned query data and `NextContext` after the query has finished during SSR. This allows to handle stuff like 404 status codes for non-existing pages. Related: #15 

Example usage:
```TypeScript
serverSidePostQuery: (queryResponse: any, ctx) => {
  if (!queryResponse?.data?.company && ctx.res) {
    ctx.res.statusCode = 404;
  }
},
```

Any feedback welcome.