### PR TITLE
Support async getClientInitialProps w backwards compabitible typing

### DIFF
--- a/example/src/pages/film/[id].tsx
+++ b/example/src/pages/film/[id].tsx
@@ -64,4 +64,10 @@ export default withRelay(Film, FilmQuery, {
 
     return createServerEnvironment();
   },
+  // clientSideProps with arbitrary sleep, 
+  // to show async or async capability
+  clientSideProps: async () => {
+    await new Promise(resolve => setTimeout(resolve, 200));
+    return {}
+  }
 });

--- a/src/wired/component.tsx
+++ b/src/wired/component.tsx
@@ -52,7 +52,7 @@ export interface WiredOptions<Props extends WiredProps, ServerSideProps = {}> {
   /** Props passed to the component when rendering on the client. */
   clientSideProps?: (
     ctx: NextPageContext
-  ) => OrRedirect<Partial<ServerSideProps>>;
+  ) => OrRedirect<Partial<ServerSideProps>> | Promise<OrRedirect<Partial<ServerSideProps>>>;
   /** Called when creating a Relay environment on the server. */
   createServerEnvironment: (
     ctx: NextPageContext,
@@ -211,14 +211,14 @@ async function getServerInitialProps<Props extends WiredProps, ServerSideProps>(
   };
 }
 
-function getClientInitialProps<Props extends WiredProps, ClientSideProps>(
+async function getClientInitialProps<Props extends WiredProps, ClientSideProps>(
   ctx: NextPageContext,
   query: GraphQLTaggedNode,
   opts: WiredOptions<Props, ClientSideProps>
 ) {
   const { variablesFromContext = defaultVariablesFromContext } = opts;
   const clientSideProps = opts.clientSideProps
-    ? opts.clientSideProps(ctx)
+    ? await opts.clientSideProps(ctx)
     : ({} as ClientSideProps);
 
   if ('redirect' in clientSideProps) {


### PR DESCRIPTION
Fixes #70

> We noticed that WiredComponent.getInitialProps is sync on client and async on server. We would be interested in them being async on either or, since it's technically allowed in [Next.JS](https://nextjs.org/docs/api-reference/data-fetching/get-initial-props)

As requested, also added backwards compatible typing, so sync and async will continue to work without issue.