### PR TITLE
feat: cache config from context

### DIFF
--- a/src/component.tsx
+++ b/src/component.tsx
@@ -17,6 +17,7 @@ import {
   useRelayEnvironment,
 } from 'react-relay';
 import {
+  CacheConfig,
   ConcreteRequest,
   Environment,
   GraphQLResponse,
@@ -85,6 +86,7 @@ export interface RelayOptions<
     queryResult: GraphQLResponse | undefined,
     ctx: NextPageContext
   ) => Promise<unknown> | unknown;
+  cacheConfigFromContext?: (ctx: NextPageContext | NextRouter) => CacheConfig;
 }
 
 function defaultVariablesFromContext(
@@ -133,6 +135,7 @@ export function withRelay<Props extends RelayProps, ServerSideProps extends {}>(
 
       const nextPreloadedQuery = loadQuery(env, query, queryVariables, {
         fetchPolicy: 'store-or-network',
+        networkCacheConfig: opts.cacheConfigFromContext?.(router),
       });
 
       setPreloadedQuery(nextPreloadedQuery);
@@ -205,6 +208,7 @@ async function getServerInitialProps<
   const variables = variablesFromContext(ctx);
   const preloadedQuery = loadQuery(env, query, variables, {
     fetchPolicy: opts.fetchPolicy ?? 'store-and-network',
+    networkCacheConfig: opts.cacheConfigFromContext?.(ctx),
   });
 
   const payload = await ensureQueryFlushed(preloadedQuery);
@@ -257,6 +261,7 @@ async function getClientInitialProps<
   const variables = variablesFromContext(ctx);
   const preloadedQuery = loadQuery(env, query, variables, {
     fetchPolicy: 'store-and-network',
+    networkCacheConfig: opts.cacheConfigFromContext?.(ctx),
   });
 
   return {


### PR DESCRIPTION
Add support for providing `cacheConfig` from context. This can be useful for a few reasons:
- Set caching config for the query
- Pass `metadata` to the fetch function

Note that its possible to achieve 2. today with `variablesFromContext` as well, but its a bit more annoying, because we don't want to send that as an actual variable to the graphql endpoint, we might want to do some conditional logic based on metadata, or send special headers.