### PR TITLE
chore(deps): remove unused dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
-        "lodash.isequal": "^4.5.0",
-        "serialize-javascript": "^5.0.1"
+        "lodash.isequal": "^4.5.0"
       },
       "devDependencies": {
         "@types/lodash.isequal": "^4.5.6",
@@ -19,7 +18,6 @@
         "@types/react-dom": "^17.0.3",
         "@types/react-relay": "^11.0.0",
         "@types/relay-runtime": "^10.1.10",
-        "@types/serialize-javascript": "^5.0.0",
         "graphql": "^15.5.0",
         "next": "^10.0.9",
         "prettier": "^2.2.1",
@@ -305,12 +303,6 @@
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
       "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==",
-      "dev": true
-    },
-    "node_modules/@types/serialize-javascript": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/serialize-javascript/-/serialize-javascript-5.0.0.tgz",
-      "integrity": "sha512-2+ai0/OTduvDzJHRAcqDwgNwshL1TN+iAfjzJJogXPSSjTBuqPl7MI0xGqCcPx+PDFbvmziiK1H6bjDb4DcoSA==",
       "dev": true
     },
     "node_modules/anser": {
@@ -1984,6 +1976,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -2103,6 +2096,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2142,14 +2136,6 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/serialize-javascript": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
-      "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
-      "dependencies": {
-        "randombytes": "^2.1.0"
       }
     },
     "node_modules/setimmediate": {
@@ -2836,12 +2822,6 @@
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
       "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==",
-      "dev": true
-    },
-    "@types/serialize-javascript": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/serialize-javascript/-/serialize-javascript-5.0.0.tgz",
-      "integrity": "sha512-2+ai0/OTduvDzJHRAcqDwgNwshL1TN+iAfjzJJogXPSSjTBuqPl7MI0xGqCcPx+PDFbvmziiK1H6bjDb4DcoSA==",
       "dev": true
     },
     "anser": {
@@ -4234,6 +4214,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
       }
@@ -4334,7 +4315,8 @@
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -4358,14 +4340,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true
-    },
-    "serialize-javascript": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
-      "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
-      "requires": {
-        "randombytes": "^2.1.0"
-      }
     },
     "setimmediate": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -33,15 +33,13 @@
     "@types/react-dom": "^17.0.3",
     "@types/react-relay": "^11.0.0",
     "@types/relay-runtime": "^10.1.10",
-    "@types/serialize-javascript": "^5.0.0",
     "graphql": "^15.5.0",
     "next": "^10.0.9",
     "prettier": "^2.2.1",
     "typescript": "^5.0.4"
   },
   "dependencies": {
-    "lodash.isequal": "^4.5.0",
-    "serialize-javascript": "^5.0.1"
+    "lodash.isequal": "^4.5.0"
   },
   "files": [
     "*.js",


### PR DESCRIPTION
Had `serialize-javascript` come up for a vulnerability warning (< 6.0.2). Typically I just force bump it with `package.json`, but this time around I wanted to checkout the source code.

It seems like relay-nextjs isn't even using the package? Dug around in older git history and seems like it was at one point used, but not anymore. Let me know if I'm mistaken, and I'll bump it instead.

Thanks!